### PR TITLE
ci: add on-PR-close workflow to create draft releases

### DIFF
--- a/.github/workflows/on-pull-request-close.yml
+++ b/.github/workflows/on-pull-request-close.yml
@@ -1,0 +1,103 @@
+name: "PR: Closed"
+run-name: >-
+  ${{ github.event.pull_request.merged == true
+    && format('PR: Merged by @{0}', github.actor)
+    || format('PR: Closed by @{0}', github.actor) }}
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  pr-merged:
+    name: "PR Merged"
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: "Semantic Versioning"
+        id: semver
+        uses: paulhatch/semantic-version@v6.0.2
+        with:
+          tag_prefix: "v"
+          major_pattern: "/(MAJOR)|!:|BREAKING CHANGE:/"
+          minor_pattern: '/feat(?!!)(\(.*\))?:/'
+          minor_regexp_flags: "i"
+          bump_each_commit: false
+          search_commit_body: true
+
+      - name: "Create or Update Draft Release"
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              const { data: releases } = await github.rest.repos.listReleases({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 10
+              });
+
+              // Remove any existing draft release for the same version
+              for (const release of releases) {
+                if (release && release.draft === true && release.tag_name === '${{ steps.semver.outputs.version_tag }}') {
+                  await github.rest.repos.deleteRelease({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    release_id: release.id
+                  });
+                }
+              }
+
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: '${{ steps.semver.outputs.version_tag }}',
+                target_commitish: 'main',
+                name: '${{ steps.semver.outputs.version_tag }}',
+                draft: true,
+                prerelease: false,
+                generate_release_notes: true,
+              });
+            } catch (error) {
+              core.setFailed(error.message);
+            }
+
+      - name: "Comment on PR"
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              const currentDate = new Date().toLocaleString('en-US', {timeZone: 'America/New_York'});
+
+              const output = `<!-- Comment created by on-pull-request-close.yml -->
+
+            ### 📦 Draft Release Created
+
+            Version: \`${{ steps.semver.outputs.version_tag }}\`
+
+            > Publish the draft release to trigger the full release workflow (GoReleaser).
+
+            *Merged by: @${{ github.actor }} on ${currentDate}*`;
+
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              });
+            } catch (error) {
+              core.setFailed(error.message);
+            }

--- a/.github/workflows/on-pull-request-close.yml
+++ b/.github/workflows/on-pull-request-close.yml
@@ -16,6 +16,9 @@ jobs:
     name: "PR Merged"
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
+    concurrency:
+      group: create-release-${{ github.repository }}
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/on-pull-request-close.yml
+++ b/.github/workflows/on-pull-request-close.yml
@@ -49,7 +49,7 @@ jobs:
               const { data: releases } = await github.rest.repos.listReleases({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                per_page: 10
+                per_page: 100
               });
 
               // Remove any existing draft release for the same version

--- a/.github/workflows/on-pull-request-close.yml
+++ b/.github/workflows/on-pull-request-close.yml
@@ -39,10 +39,13 @@ jobs:
 
       - name: "Create or Update Draft Release"
         uses: actions/github-script@v8
+        env:
+          VERSION_TAG: ${{ steps.semver.outputs.version_tag }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             try {
+              const versionTag = process.env.VERSION_TAG;
               const { data: releases } = await github.rest.repos.listReleases({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -51,7 +54,7 @@ jobs:
 
               // Remove any existing draft release for the same version
               for (const release of releases) {
-                if (release && release.draft === true && release.tag_name === '${{ steps.semver.outputs.version_tag }}') {
+                if (release && release.draft === true && release.tag_name === versionTag) {
                   await github.rest.repos.deleteRelease({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
@@ -63,9 +66,9 @@ jobs:
               await github.rest.repos.createRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                tag_name: '${{ steps.semver.outputs.version_tag }}',
+                tag_name: versionTag,
                 target_commitish: 'main',
-                name: '${{ steps.semver.outputs.version_tag }}',
+                name: versionTag,
                 draft: true,
                 prerelease: false,
                 generate_release_notes: true,

--- a/.github/workflows/on-pull-request-close.yml
+++ b/.github/workflows/on-pull-request-close.yml
@@ -79,21 +79,26 @@ jobs:
 
       - name: "Comment on PR"
         uses: actions/github-script@v8
+        env:
+          VERSION_TAG: ${{ steps.semver.outputs.version_tag }}
+          ACTOR: ${{ github.actor }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             try {
-              const currentDate = new Date().toLocaleString('en-US', {timeZone: 'America/New_York'});
+              const currentDate = new Date().toISOString();
+              const versionTag = process.env.VERSION_TAG;
+              const actor = process.env.ACTOR;
 
               const output = `<!-- Comment created by on-pull-request-close.yml -->
 
             ### 📦 Draft Release Created
 
-            Version: \`${{ steps.semver.outputs.version_tag }}\`
+            Version: \`${versionTag}\`
 
             > Publish the draft release to trigger the full release workflow (GoReleaser).
 
-            *Merged by: @${{ github.actor }} on ${currentDate}*`;
+            *Merged by: @${actor} on ${currentDate}*`;
 
               await github.rest.issues.createComment({
                 issue_number: context.issue.number,

--- a/.github/workflows/on-pull-request-close.yml
+++ b/.github/workflows/on-pull-request-close.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: "Semantic Versioning"
         id: semver
-        uses: paulhatch/semantic-version@v6.0.2
+        uses: paulhatch/semantic-version@8da30f99b5b2e7a26ced60b1dad2e41756d6edf4 # v6.0.2
         with:
           tag_prefix: "v"
           major_pattern: "/(MAJOR)|!:|BREAKING CHANGE:/"
@@ -38,7 +38,7 @@ jobs:
           search_commit_body: true
 
       - name: "Create or Update Draft Release"
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           VERSION_TAG: ${{ steps.semver.outputs.version_tag }}
         with:
@@ -78,10 +78,10 @@ jobs:
             }
 
       - name: "Comment on PR"
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           VERSION_TAG: ${{ steps.semver.outputs.version_tag }}
-          ACTOR: ${{ github.actor }}
+          ACTOR: ${{ github.event.pull_request.merged_by.login || github.actor }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary

- Adds a new `on-pull-request-close.yml` workflow that runs when PRs are merged to `main`
- Computes the next semantic version from conventional commit prefixes using `paulhatch/semantic-version`
- Creates a draft GitHub release with auto-generated release notes
- Comments on the merged PR with the draft release version
- Publishing the draft release creates the `v*` tag, which triggers the existing `release.yml` (GoReleaser)

## Test plan

- [ ] Merge a PR with a `feat:` commit and verify a minor version bump draft release is created
- [ ] Merge a PR with a `fix:` commit and verify a patch version bump draft release is created
- [ ] Publish the draft release and verify GoReleaser runs via `release.yml`
- [ ] Verify the PR comment includes the correct version tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated release management triggered when pull requests are merged to main: computes a semantic version tag, refreshes any existing draft release for that tag, creates a new draft release with auto-generated release notes targeting main, and comments the merged PR with the computed version, merged-by actor, and ISO timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->